### PR TITLE
Upload results per org to S3

### DIFF
--- a/helmScanner/output/s3_uploader.py
+++ b/helmScanner/output/s3_uploader.py
@@ -7,12 +7,14 @@ import boto3
 s3 = boto3.client('s3')
 
 
-def upload_results_to_s3(results_path, scan_time):
+def upload_results_to_s3(results_path, scan_time, partialUpload):
     for filename in os.listdir(results_path):
         if filename.lower().endswith('.csv'):
             s3.upload_file(f'{results_path}/{filename}', os.environ['RESULT_BUCKET'], f'results/{scan_time}/{filename}')
             helmscanner_logging.info(f'Uploaded {filename}')
-
+            if partialUpload:
+                helmscanner_logging.info(f'Partial upload selected, renaming {filename} to {filename}.uploaded')
+                os.rename(filename, filename.uploaded)
 
 
 def upload_results(results_path, scan_time):

--- a/helmScanner/runner.py
+++ b/helmScanner/runner.py
@@ -62,7 +62,7 @@ def parse_helm_dependency_output(o):
 
 def scan_files():
     crawler = artifactHubCrawler.ArtifactHubCrawler()
-    crawlDict, totalRepos, totalPackages = crawler.mockCrawl()
+    crawlDict, totalRepos, totalPackages = crawler.crawl()
     helmscanner_logging.info(f"Crawl completed with {totalPackages} charts from {totalRepos} repositories.")
 
     crawlList = crawlDict
@@ -368,11 +368,15 @@ def _scan_org(crawlList, orgOffset):
     helmscanner_logging.debug(f"Global deps list {globalDepsList}")
 
     result_writer.print_csv(summary_lst, result_lst, helmdeps_lst, empty_resources, RESULTS_PATH, repo['repoName'], orgRepoFilename, globalDepsList, globalDepsUsage)
-    #empty_resources_total.update(empty_resources)
+    #Upload and rename per org, rather than waiting till the end of the run.
+    uploadResultsPartial()
+
+def uploadResultsPartial():
+    if os.environ.get('RESULT_BUCKET'):
+        helmscanner_logging.info(f'Uploading results to {os.environ["RESULT_BUCKET"]}')
+        s3_uploader.upload_results(RESULTS_PATH, SCAN_TIME, True)
 
 def run():
     scan_files()
     
-    if os.environ.get('RESULT_BUCKET'):
-        helmscanner_logging.info(f'Uploading results to {os.environ["RESULT_BUCKET"]}')
-        s3_uploader.upload_results(RESULTS_PATH, SCAN_TIME)
+


### PR DESCRIPTION
- Upload per org to S3, not at the end of the run.
- Add error handling to twistcli processing which caused run to fail